### PR TITLE
Add new Vite React tropics app

### DIFF
--- a/apps/tropics/index.html
+++ b/apps/tropics/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Tropic Study</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/apps/tropics/package.json
+++ b/apps/tropics/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@onlook/tropics",
+    "version": "0.0.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "format": "prettier --write .",
+        "lint": "eslint ."
+    },
+    "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+    },
+    "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.2.1",
+        "vite": "^5.0.0",
+        "prettier": "^3.5.3",
+        "eslint": "^9.23.0",
+        "typescript": "^5.5.4"
+    }
+}

--- a/apps/tropics/src/App.tsx
+++ b/apps/tropics/src/App.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function App() {
+    return (
+        <main style={{ textAlign: 'center', fontFamily: 'sans-serif' }}>
+            <h1>Learn the Tropic Lines</h1>
+            <svg width="400" height="200" viewBox="0 0 400 200">
+                <circle cx="200" cy="100" r="90" fill="#e0f7fa" stroke="#006064" />
+                <line x1="110" y1="60" x2="290" y2="60" stroke="#ff5722" strokeWidth="2" />
+                <line x1="110" y1="140" x2="290" y2="140" stroke="#ff5722" strokeWidth="2" />
+                <text x="295" y="64" fontSize="10" fill="#333">
+                    Tropic of Cancer
+                </text>
+                <text x="295" y="144" fontSize="10" fill="#333">
+                    Tropic of Capricorn
+                </text>
+            </svg>
+            <p style={{ maxWidth: 500, margin: '1rem auto' }}>
+                The Tropic of Cancer and Tropic of Capricorn are located approximately 23.4° north
+                and south of the equator. They mark the furthest latitudes where the sun can appear
+                directly overhead.
+            </p>
+        </main>
+    );
+}

--- a/apps/tropics/src/index.css
+++ b/apps/tropics/src/index.css
@@ -1,0 +1,4 @@
+body {
+    margin: 0;
+    padding: 0;
+}

--- a/apps/tropics/src/main.tsx
+++ b/apps/tropics/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>,
+);

--- a/apps/tropics/tsconfig.json
+++ b/apps/tropics/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        "module": "esnext",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "jsx": "react-jsx",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "types": ["vite/client"]
+    },
+    "include": ["src"]
+}

--- a/apps/tropics/vite.config.ts
+++ b/apps/tropics/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [react()],
+});


### PR DESCRIPTION
## Description
Add a new `apps/tropics` workspace containing a minimal React + Vite project. The app displays a simple SVG illustration of the Tropic of Cancer and Tropic of Capricorn and brief descriptive text.

## Related Issues


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Release
- [ ] Refactor
- [ ] Other (please describe):

## Testing
- `bun format`
- `bun lint` *(failed: `next` command not found)*
- `bun test` *(failed: multiple missing modules)*

## Screenshots (if applicable)


## Additional Notes
Lint and test commands failed due to missing dependencies in the environment.

------
https://chatgpt.com/codex/tasks/task_e_6854eef1f8488331b87824fa00233c35